### PR TITLE
Abort on error updating alerts

### DIFF
--- a/main.go
+++ b/main.go
@@ -4,14 +4,15 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"github.com/fatih/color"
-	"github.com/joho/godotenv"
-	"github.com/mitchellh/go-homedir"
-	"gopkg.in/resty.v1"
 	"log"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/fatih/color"
+	"github.com/joho/godotenv"
+	"github.com/mitchellh/go-homedir"
+	"gopkg.in/resty.v1"
 )
 
 type statusResponse struct {

--- a/main.go
+++ b/main.go
@@ -200,11 +200,14 @@ func alertsEnable() {
 				} else {
 					fmt.Println("enabling alert " + alertName)
 					alert.Active = true
-					_, updateErr := resty.R().
+					result, updateErr := resty.R().
 						SetBody(alert).
 						Put("https://metrics-api.librato.com/v1/alerts/" + strconv.Itoa(alert.ID))
 					if updateErr != nil {
 						log.Fatal("Error updating alert " + alert.Name)
+					}
+					if result.IsError() {
+						log.Fatalf("Error updating alter %v: Return code (%v), Return body %v", alert.Name, result.StatusCode(), string(result.Body()))
 					}
 					fmt.Println(alert.Name + " enabled")
 				}
@@ -232,11 +235,14 @@ func alertsDisable() {
 				if alert.Active {
 					fmt.Println("disabling alert " + alert.Name)
 					alert.Active = false
-					_, updateErr := resty.R().
+					result, updateErr := resty.R().
 						SetBody(alert).
 						Put("https://metrics-api.librato.com/v1/alerts/" + strconv.Itoa(alert.ID))
 					if updateErr != nil {
 						log.Fatal("Error updating alert " + alert.Name)
+					}
+					if result.IsError() {
+						log.Fatalf("Error updating alter %v: Return code (%v), Return body %v", alert.Name, result.StatusCode(), string(result.Body()))
 					}
 					fmt.Println(alert.Name + " disabled")
 				} else {


### PR DESCRIPTION
This avoids a false update on error. API returns a 400 / 500 error when someting fails and this erros was not captured. This way execution aborts and print diagnose input if the API fails but the call does not.

- Capture errors updating alerts.
- Automated changes made by goimport
