### PR TITLE
Set a description in the alert when updating

### DIFF
--- a/main.go
+++ b/main.go
@@ -201,6 +201,9 @@ func alertsEnable() {
 				} else {
 					fmt.Println("enabling alert " + alertName)
 					alert.Active = true
+					if alert.Description == "" {
+						alert.Description = "-"
+					}
 					result, updateErr := resty.R().
 						SetBody(alert).
 						Put("https://metrics-api.librato.com/v1/alerts/" + strconv.Itoa(alert.ID))
@@ -236,6 +239,9 @@ func alertsDisable() {
 				if alert.Active {
 					fmt.Println("disabling alert " + alert.Name)
 					alert.Active = false
+					if alert.Description == "" {
+						alert.Description = "-"
+					}
 					result, updateErr := resty.R().
 						SetBody(alert).
 						Put("https://metrics-api.librato.com/v1/alerts/" + strconv.Itoa(alert.ID))


### PR DESCRIPTION
For some weird reasons the optional field Description is not always optional. It seems that you can create an alert w/o description but you can't edit it. This caused errors when the alert was enabled or disabled so this commit adds a dummy description if the alert was created without one.
